### PR TITLE
which-key keycap symbols

### DIFF
--- a/config.org
+++ b/config.org
@@ -1972,7 +1972,8 @@ I get a popup buffer that tells me what bindings I am able to use.
     (which-key-setup-side-window-right)
     (add-to-list 'which-key-replacement-alist '(("TAB" . nil) . ("↹" . nil)))
     (add-to-list 'which-key-replacement-alist '(("RET" . nil) . ("⏎" . nil)))
-    (add-to-list 'which-key-replacement-alist '(("DEL" . nil) . ("⇤" . nil)))
+    (add-to-list 'which-key-replacement-alist '(("DEL" . nil) . ("⌦" . nil)))
+    (add-to-list 'which-key-replacement-alist '(("ESC" . nil) . ("⎋" . nil)))
     (add-to-list 'which-key-replacement-alist '(("SPC" . nil) . ("␣" . nil)))
 
     (which-key-mode)


### PR DESCRIPTION
Hello Karl,

liked your which-key part to replace the key abbreviation with Unicode keycap symbols and added it to my configuration.

I added the ISO/IEC 9995-7 symbol 29 (source [Wikipedia](https://en.wikipedia.org/wiki/Esc_key)) "broken circle with northwest arrow" for the missing ESC.
Also for DEL you used the leftwards tab key symbol. As leftwards arrows are normally used for backspace I replaced this with the ISO "erase to the right" symbol.

Thanks for all your great work relating to Emacs and Org-mode

Markus